### PR TITLE
Created alternative distribution chart that only shows the split betw…

### DIFF
--- a/lib/models/portfolio_datapoint.dart
+++ b/lib/models/portfolio_datapoint.dart
@@ -18,3 +18,8 @@ enum InstrumentType {
   cash,
   other,
 }
+
+enum ValueType {
+  amount,
+  percentage,
+}

--- a/lib/screens/overview_screen.dart
+++ b/lib/screens/overview_screen.dart
@@ -7,6 +7,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:indexa_dashboard/widgets/account_summary.dart';
 import 'package:indexa_dashboard/widgets/reusable_card.dart';
 import 'package:indexa_dashboard/widgets/distribution_chart.dart';
+import 'package:indexa_dashboard/widgets/distribution_chart_simplified.dart';
 import 'package:indexa_dashboard/widgets/distribution_legend.dart';
 import 'package:indexa_dashboard/widgets/profit_popup.dart';
 import 'package:indexa_dashboard/models/account_dropdown_items.dart';
@@ -107,6 +108,8 @@ class _OverviewScreenState extends State<OverviewScreen> {
                               ),
                               DistributionChart(
                                   portfolioData: accountData.portfolioData),
+                              // DistributionChartSimplified(
+                              //     portfolioDistribution: accountData.portfolioDistribution),
                               DistributionChartLegend(
                                   portfolioDistribution:
                                       accountData.portfolioDistribution),

--- a/lib/screens/root_screen.dart
+++ b/lib/screens/root_screen.dart
@@ -230,14 +230,15 @@ class _RootScreenState extends State<RootScreen> {
               if (reloading) {
                 child = Center(child: CircularProgressIndicator());
               } else {
+                // ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                //   content: Text(snapshot.error.toString()),
+                // ));
                 child = Center(
                   child: Column(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: <Widget>[
-                      Icon(
-                        Icons.cloud_off,
-                      ),
-                      Text("Error loading data"),
+                      Icon(Icons.error_outline),
+                      Text(snapshot.error.toString()),
                       MaterialButton(
                         child: Text(
                           'retry'.tr(),

--- a/lib/widgets/distribution_chart_simplified.dart
+++ b/lib/widgets/distribution_chart_simplified.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:indexa_dashboard/models/portfolio_datapoint.dart';
+import 'package:syncfusion_flutter_charts/charts.dart';
+import 'package:easy_localization/easy_localization.dart';
+import '../tools/constants.dart';
+
+class DistributionChartSimplified extends StatelessWidget {
+  const DistributionChartSimplified({
+    Key key,
+    @required this.portfolioDistribution,
+  }) : super(key: key);
+  final Map<InstrumentType, Map<ValueType, double>> portfolioDistribution;
+
+  @override
+  Widget build(BuildContext context) {
+    List<Color> colorList = [equityColors[2], fixedColors[2], cashColor, otherColor];
+
+    return Container(
+      height: 280,
+      child: SfCircularChart(
+        palette: colorList,
+        //backgroundColor: Colors.blueGrey,
+        tooltipBehavior: TooltipBehavior(
+          enable: true,
+          decimalPlaces: 2,
+          format: 'point.x' + '\npoint.y €',
+        ),
+        series: <CircularSeries>[
+          // Renders doughnut chart
+          DoughnutSeries<InstrumentType, String>(
+            dataSource: portfolioDistribution.keys.toList(),
+            xValueMapper:
+                (InstrumentType currentInstrumentType, _) {
+              if (currentInstrumentType == InstrumentType.equity) {
+                return 'distribution_chart.instrument_type_equity'.tr() +
+                    '\n(' +
+                    (portfolioDistribution[currentInstrumentType][ValueType.percentage] * 100)
+                        .toStringAsFixed(1) +
+                    '%)';
+                } else if (currentInstrumentType == InstrumentType.fixed) {
+                return 'distribution_chart.instrument_type_fixed'.tr() +
+                    '\n(' +
+                    (portfolioDistribution[currentInstrumentType][ValueType.percentage] * 100)
+                        .toStringAsFixed(1) +
+                    '%)';
+              } else if (currentInstrumentType == InstrumentType.cash) {
+                return 'distribution_chart.instrument_type_cash'.tr() +
+                    '\n(' +
+                    (portfolioDistribution[currentInstrumentType][ValueType.percentage] * 100)
+                        .toStringAsFixed(1) +
+                    '%)';
+              } else {
+                return 'distribution_chart.instrument_type_other'.tr() +
+                    '\n(' +
+                    (portfolioDistribution[currentInstrumentType][ValueType.percentage] * 100)
+                        .toStringAsFixed(1) +
+                    '%)';
+              }
+            },
+            yValueMapper:
+                (InstrumentType currentInstrumentType,
+                _) =>
+            double.parse(portfolioDistribution[currentInstrumentType][ValueType.amount].toStringAsFixed(2)),
+            dataLabelSettings:
+            DataLabelSettings(
+              margin: EdgeInsets.all(0),
+              isVisible: true,
+              textStyle: TextStyle(
+                fontSize: 10,
+              ),
+              borderWidth: 0,
+              labelPosition:
+              ChartDataLabelPosition
+                  .outside,
+              connectorLineSettings:
+              ConnectorLineSettings(
+                // Type of the connector line
+                  type:
+                  ConnectorType.line),
+              labelIntersectAction: LabelIntersectAction.none,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/distribution_legend.dart
+++ b/lib/widgets/distribution_legend.dart
@@ -9,7 +9,7 @@ class DistributionChartLegend extends StatelessWidget {
     Key key,
     @required this.portfolioDistribution,
   }) : super(key: key);
-  final Map<InstrumentType, double> portfolioDistribution;
+  final Map<InstrumentType, Map<ValueType, double>> portfolioDistribution;
 
   @override
   Widget build(BuildContext context) {
@@ -18,6 +18,7 @@ class DistributionChartLegend extends StatelessWidget {
     if (portfolioDistribution.containsKey(InstrumentType.equity)) {
       legendItems.add(
         Row(
+          mainAxisSize: MainAxisSize.min,
           children: <Widget>[
             RadiantLinearMask(
               child: Icon(
@@ -35,7 +36,7 @@ class DistributionChartLegend extends StatelessWidget {
                       text: 'distribution_legend.instrument_type_equity'.tr(),
                       style: kLegendMainTextStyle),
                   TextSpan(
-                      text:  " (" + (portfolioDistribution[InstrumentType.equity] * 100).toStringAsFixed(1) + "%)",
+                      text:  " (" + (portfolioDistribution[InstrumentType.equity][ValueType.percentage] * 100).toStringAsFixed(1) + "%)",
                       style: kLegendSecondaryTextStyle)
                 ],
               ),
@@ -47,6 +48,7 @@ class DistributionChartLegend extends StatelessWidget {
     if (portfolioDistribution.containsKey(InstrumentType.fixed)) {
       legendItems.add(
         Row(
+          mainAxisSize: MainAxisSize.min,
           children: <Widget>[
             RadiantLinearMask(
               child: Icon(
@@ -65,7 +67,7 @@ class DistributionChartLegend extends StatelessWidget {
                       style: kLegendMainTextStyle),
                   TextSpan(
                     //text: "10.000€",
-                      text:  " (" + (portfolioDistribution[InstrumentType.fixed] * 100).toStringAsFixed(1) + "%)",
+                      text:  " (" + (portfolioDistribution[InstrumentType.fixed][ValueType.percentage] * 100).toStringAsFixed(1) + "%)",
                       style: kLegendSecondaryTextStyle)
                 ],
               ),
@@ -77,6 +79,7 @@ class DistributionChartLegend extends StatelessWidget {
     if (portfolioDistribution.containsKey(InstrumentType.other)) {
       legendItems.add(
         Row(
+          mainAxisSize: MainAxisSize.min,
           children: <Widget>[
             Icon(
               Icons.fiber_manual_record,
@@ -91,7 +94,7 @@ class DistributionChartLegend extends StatelessWidget {
                       style: kLegendMainTextStyle),
                   TextSpan(
                     //text: "10.000€",
-                      text:  " (" + (portfolioDistribution[InstrumentType.other] * 100).toStringAsFixed(1) + "%)",
+                      text:  " (" + (portfolioDistribution[InstrumentType.other][ValueType.percentage] * 100).toStringAsFixed(1) + "%)",
                       style: kLegendSecondaryTextStyle)
                 ],
               ),
@@ -103,6 +106,7 @@ class DistributionChartLegend extends StatelessWidget {
     if (portfolioDistribution.containsKey(InstrumentType.cash)) {
       legendItems.add(
         Row(
+          mainAxisSize: MainAxisSize.min,
           children: <Widget>[
             Icon(
               Icons.fiber_manual_record,
@@ -113,11 +117,11 @@ class DistributionChartLegend extends StatelessWidget {
               text: TextSpan(
                 children: [
                   TextSpan(
-                      text: 'distribution_legend.instrument_type_other'.tr(),
+                      text: 'distribution_legend.instrument_type_cash'.tr(),
                       style: kLegendMainTextStyle),
                   TextSpan(
                     //text: "10.000€",
-                      text:  " (" + (portfolioDistribution[InstrumentType.cash] * 100).toStringAsFixed(1) + "%)",
+                      text:  " (" + (portfolioDistribution[InstrumentType.cash][ValueType.percentage] * 100).toStringAsFixed(1) + "%)",
                       style: kLegendSecondaryTextStyle)
                 ],
               ),
@@ -126,9 +130,10 @@ class DistributionChartLegend extends StatelessWidget {
         ),
       );
     }
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+    return Wrap(
       children: legendItems,
+      spacing: 10,
+      runSpacing: 5,
     );
   }
 }


### PR DESCRIPTION
Created alternative distribution chart that only shows the split between equity, fixed, cash and others. Fixed the legend of the chart overflowing if there are 4 items (the usual 3 + 'others'). Fixed logic that detects whether the 'other' item should be present. Expanded the portfolio distribution object to also contain the total amounts of each asset time, not just the percentage. This was needed to properly display the labels of the new simplified chart.