### PR TITLE
Fix crash when logging in with account in opening process

### DIFF
--- a/assets/translations/en-US.json
+++ b/assets/translations/en-US.json
@@ -46,7 +46,8 @@
     "screen_lock_required": "An active screen lock must be enabled to store the token locally.",
     "invalid_token_format": "Invalid token format",
     "no_active_accounts": "No active accounts found for this user",
-    "default_error_message": "Couldn't load data"
+    "default_error_message": "Couldn't load data",
+    "account_not_ready": "Account data is not ready yet. This may happen if the account is still being opened."
   },
   "root_screen": {
     "private_mode_enabled": "Private mode enabled",

--- a/assets/translations/es-ES.json
+++ b/assets/translations/es-ES.json
@@ -46,7 +46,8 @@
     "screen_lock_required": "Para guardar el token en el dispositivo, el bloqueo de pantalla debe estar activado.",
     "invalid_token_format": "Formato de token no válido",
     "no_active_accounts": "No se encontraron cuentas activas para este usuario",
-    "default_error_message": "No se pudieron cargar los datos"
+    "default_error_message": "No se pudieron cargar los datos",
+    "account_not_ready": "Los datos de la cuenta aún no están listos. Esto puede ocurrir si la cuenta aún se está abriendo."
   },
   "root_screen": {
     "private_mode_enabled": "Modo privado activado",

--- a/assets/translations/gl-ES.json
+++ b/assets/translations/gl-ES.json
@@ -46,7 +46,8 @@
     "screen_lock_required": "Para gardar o teu token no dispositivo, o bloqueo da pantalla debe estar activa.",
     "invalid_token_format": "Formato de token non válido",
     "no_active_accounts": "Non se toparon contas activas para este usuario",
-    "default_error_message": "Non se puideron carga-los datos"
+    "default_error_message": "Non se puideron carga-los datos",
+    "account_not_ready": "Os datos da conta aínda non están listos. Isto pode ocorrer se a conta aínda se está abrindo."
   },
   "root_screen": {
     "private_mode_enabled": "Modo privado activado",

--- a/lib/tools/account_operations.dart
+++ b/lib/tools/account_operations.dart
@@ -28,6 +28,9 @@ String testEmergencyFundDescription =
 /* End of test settings for emergency fund */
 
 List<AmountsDataPoint> createAmountsSeries(netAmountsList, totalAmountsList) {
+  if (totalAmountsList?.keys == null || netAmountsList?.keys == null) {
+    throw Exception("login_screen.account_not_ready".tr());
+  }
   // Creates a time series with the value of the portfolio overtime
   List<AmountsDataPoint> newAmountSeries = [];
   totalAmountsList.keys.forEach((k) {


### PR DESCRIPTION
Fixes #79

## Problem

The app crashes when logging in with an account that's still being set up. It fails in `createAmountsSeries()` when trying to call `.keys` on null - the API returns null for these accounts instead of the expected map.

## Solution
Added null checks in `createAmountsSeries()` to throw an exception when the data isn't available yet. The existing error handler in `RootScreen._loadData()` already redirects to login and shows the error in a snackbar, so I just needed to catch this case. The message will show "Exception:" prefix followed by the error message, keeping consistency with other error messages in the app.

## Changes
- Added null validation in `createAmountsSeries()` 
- Added `login_screen.account_not_ready` translation key (EN/ES/GL)
- Error message: "Account data is not ready yet. This may happen if the account is still being opened."

## Testing
Tested by forcing the exception to make sure it redirects properly and shows the message.